### PR TITLE
Fix random_string format

### DIFF
--- a/installer/main.tf
+++ b/installer/main.tf
@@ -15,12 +15,14 @@
  */
 
 data "google_compute_default_service_account" "default" {
+  project = var.project_id
 }
 
 resource "random_string" "backend_name" {
   length  = 4
   special = false
-  lower   = true
+  lower   = true            
+  upper   = false
 }
 
 resource "google_project_service" "compute" {


### PR DESCRIPTION
Disallow uppercase to guarantee the validation regex is respected: `[a-z]([-a-z0-9]*[a-z0-9])?` and add required project var to service_account

More info here: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address